### PR TITLE
Save to localStorage when merging to uniques

### DIFF
--- a/plugins/uniques-gdpr.user.js
+++ b/plugins/uniques-gdpr.user.js
@@ -190,6 +190,8 @@ window.plugin.uniquesGdpr.mergeWithUniques = function() {
     }
   });
   changes.sort();
+  
+  window.plugin.uniques.storeLocal('uniques');
 
   if(window.plugin.sync) {
     window.plugin.sync.updateMap('uniques', 'uniques', Object.keys(window.plugin.uniques.uniques));


### PR DESCRIPTION
When merging the gdpr plugin data with uniques plugin, I noticed it wasn't stored on the local storage (`localStorage['plugin-uniques-data']`) so after a page reload the merged uniques data was gone. I fixed it by explicitly calling the `storeLocal()` method of the uniques plugin.